### PR TITLE
Add --hostID configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,3 +16,4 @@ options:
 schema:
   host: str
   port: int
+  hostID: "str?"

--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,9 @@
 
 echo "Starting snapclient..."
 
-snapclient -h $(bashio::config 'host') -p $(bashio::config 'port')
+hostID=""
+if bashio::config.exists 'hostID'; then
+    hostID="--hostID $(bashio::config 'hostID')"
+fi
+
+snapclient -h $(bashio::config 'host') -p $(bashio::config 'port') $hostID


### PR DESCRIPTION
This allows setting a static hostID since the MAC address of docker containers on HASS OS will occasionally change, creating orphaned clients on the snapserver and changing your entity ID in the snapcast integration.